### PR TITLE
Improving completion of subcommands

### DIFF
--- a/__diraction-dispatch
+++ b/__diraction-dispatch
@@ -103,7 +103,7 @@ else # argument completion
             if functions "$compfun" > /dev/null; then
                 # §tofix: git error: zsh:12: command not found: ___diraction-dispatch_main # ¤old
                 # if so do it up
-                cd $PWD; $compfun ; ret=$? ; cd $OLDPWD; [ $ret -eq 0 ] && return 0
+                cd $PWD; service="$subcommand" $compfun ; ret=$? ; cd $OLDPWD; [ $ret -eq 0 ] && return 0
                 # beware to file completion:
                 # https://github.com/robbyrussell/oh-my-zsh/issues/2394
             else

--- a/__diraction-dispatch
+++ b/__diraction-dispatch
@@ -79,12 +79,21 @@ else # argument completion
     shift words; shift words  # shifting words args
     ((CURRENT = CURRENT -2))
     case $subcommand in
+        # note: In order for forwarded sub command completion (_some_subcmd) to work correctly "service" should be set to the $subcmd
+        #
+        # see http://zsh.sourceforge.net/Doc/Release/Completion-System.html  20.2.2 Autoloaded files (#compdef section):
+        # > Each name may also be of the form 'cmd=service'. When completing the command cmd, the function typically behaves as
+        # if the command (or special context) service was being completed instead. This provides a way of altering the behaviour
+        # of functions that can perform many different completions. It is implemented by setting the parameter $service when
+        # calling the function; the function may choose to interpret this how it wishes, and simpler functions will probably ignore it.
+
         e|"exec"|[-,_])  # magic native completion
             shift words; ((CURRENT--))
             if  ((CURRENT == 1 )); then
                 _command_names
             elif functions "_${words[1]}" > /dev/null; then
-                cd $PWD && "_${words[1]}" ; cd $OLDPWD
+                # note: ${words[1]} is the real subcommand, `-` only forward
+                cd $PWD && service="${words[1]}" "_${words[1]}" ; cd $OLDPWD
             else
                 _path_files -W $PWD ; _options_set
             fi ; return 0

--- a/test/diraction_dispatcher_completion_shpec.zsh
+++ b/test/diraction_dispatcher_completion_shpec.zsh
@@ -26,6 +26,7 @@ completion_commands=(compadd _message _command_names _path_files _directories _l
 for cmd in $completion_commands; do
     stub_command $cmd "echo $cmd "'$@ '
 done
+stub_command _git "echo _git "'service=$service $@ '
 
 describe "Dispatcher Completion"
   it "Completion with no args"
@@ -115,6 +116,18 @@ describe "Dispatcher Completion"
       CURRENT=5 words=(__diraction-dispatch $QUOTED_DIR_DIR - ls alo)
       output="$(__diraction-dispatch)"
       assert grep "$output" "_ls"
+    end
+
+    it "argument of whitelisted command (checking service injection)"
+      CURRENT=5 words=(__diraction-dispatch $QUOTED_DIR_DIR git stat)
+      output="$(__diraction-dispatch)"
+      assert grep "$output" "_git service=git"
+    end
+
+    it "argument of command with completion command available (checking service injection)"
+      CURRENT=5 words=(__diraction-dispatch $QUOTED_DIR_DIR - git stat)
+      output="$(__diraction-dispatch)"
+      assert grep "$output" "_git service=git"
     end
 
     it "argument of command with no completion command available"


### PR DESCRIPTION
The service variable gets used by, e.g., `git`. Not setting it will break those completions.